### PR TITLE
Update blog URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ permalink: /:year/:month/:day/:title/
 title:            Daniele Esposti's Blog
 # tagline:          'blog'
 description:      'My personal blog.'
-url:              https://www.expobrain.net
+url:              https://expobrain.net
 baseurl:
 commentsystem:    disqus
 disqus:           expobrain


### PR DESCRIPTION
www.expobrain.net seems to have SSL issue and that's the link that opens when I click "Daniele Esposti's Blog"