### PR TITLE
Use rellative URLs for site navigation

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,21 +17,21 @@ It's a good idea to keep this template as minimal as possible in terms of both f
     <title>{{ page.title }}</title>
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.css" | absolute_url }}" />
-    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.edited.css" | absolute_url }}" />
+    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.css" | relative_url }}" />
+    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.edited.css" | relative_url }}" />
     <!-- This tag outputs SEO meta+structured data and other important settings -->
     {% include head.html %}
 </head>
 <body class="error-template">
     <div class="site-wrapper">
 
-        <header class="site-header outer {% if page.cover %}" style="background-image: url({{ page.cover | absolute_url }})){% else %}no-cover{% endif %}">
+        <header class="site-header outer {% if page.cover %}" style="background-image: url({{ page.cover | relative_url }})){% else %}no-cover{% endif %}">
             <div class="inner">
                 <nav class="site-nav-center">
                     {% if site.logo %}
-                        <a class="site-nav-logo" href="{{ "" | absolute_url }}"><img src="{{ site.logo | absolute_url }}" alt="{{ site.title }}" /></a>
+                        <a class="site-nav-logo" href="{{ "" | relative_url }}"><img src="{{ site.logo | relative_url }}" alt="{{ site.title }}" /></a>
                     {% else %}
-                        <a class="site-nav-logo" href="{{ "" | absolute_url }}">{{ site.title }}</a>
+                        <a class="site-nav-logo" href="{{ "" | relative_url }}">{{ site.title }}</a>
                     {% endif %}
                 </nav>
             </div>
@@ -43,7 +43,7 @@ It's a good idea to keep this template as minimal as possible in terms of both f
                 <section class="error-message">
                     <h1 class="error-code">404</h1>
                     <p class="error-description">Page not found</p>
-                    <a class="error-link" href="{{ "" | absolute_url }}">Go to the front page →</a>
+                    <a class="error-link" href="{{ "" | relative_url }}">Go to the front page →</a>
                 </section>
             </div>
         </main>

--- a/_includes/author_pagination.html
+++ b/_includes/author_pagination.html
@@ -1,13 +1,13 @@
 <nav class="pagination" role="pagination">
     {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-            <a class="newer-posts" href="{{ "author" | absolute_url }}/{{ page.author }}" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "author" | relative_url }}/{{ page.author }}" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{ "author" | absolute_url }}/{{ page.author }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "author" | relative_url }}/{{ page.author }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{ paginator.page }} of {{ paginator.total_pages }} </span>
     {% if paginator.next_page %}
-        <a class="older-posts" href="{{ "author" | absolute_url }}/{{ page.author }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
+        <a class="older-posts" href="{{ "author" | relative_url }}/{{ page.author }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
     {% endif %}
 </nav>

--- a/_includes/floating-header.html
+++ b/_includes/floating-header.html
@@ -1,8 +1,8 @@
 <div class="floating-header">
     <div class="floating-header-logo">
-        <a href="{{ "" | absolute_url }}">
+        <a href="{{ "" | relative_url }}">
             {% if site.logo_dark %}
-                <img src="{{ site.logo_dark | absolute_url }}" alt="{{ site.title }} icon" />
+                <img src="{{ site.logo_dark | relative_url }}" alt="{{ site.title }} icon" />
             {% endif %}
             <span>{{ site.title }}</span>
         </a>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,4 +1,4 @@
 <ul class="nav" role="menu">
-    <li class="nav-home" role="menuitem"><a href="{{ "" |    }}">Home</a></li>
+    <li class="nav-home" role="menuitem"><a href="{{ "" | relative_url }}">Home</a></li>
     <li class="nav-about" role="menuitem"><a href="{{ "about/" | relative_url }}">About</a></li>
 </ul>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,4 +1,4 @@
 <ul class="nav" role="menu">
-    <li class="nav-home" role="menuitem"><a href="{{ "" | absolute_url }}">Home</a></li>
-    <li class="nav-about" role="menuitem"><a href="{{ "about/" | absolute_url }}">About</a></li>
+    <li class="nav-home" role="menuitem"><a href="{{ "" |    }}">Home</a></li>
+    <li class="nav-about" role="menuitem"><a href="{{ "about/" | relative_url }}">About</a></li>
 </ul>

--- a/_includes/post-card-error.html
+++ b/_includes/post-card-error.html
@@ -6,12 +6,12 @@
     {% if count <= 3 %}
         <article class="post-card {{ page.class }}{% unless post.cover %} no-image{% endunless %}">
             {% if post.cover %}
-                <a class="post-card-image-link" href="{{ post.url | remove_first: '/' | absolute_url }}">
-                    <div class="post-card-image" style="background-image: url({{ post.cover | absolute_url }})"></div>
+                <a class="post-card-image-link" href="{{ post.url | remove_first: '/' | relative_url }}">
+                    <div class="post-card-image" style="background-image: url({{ post.cover | relative_url }})"></div>
                 </a>
             {% endif %}
             <div class="post-card-content">
-                <a class="post-card-content-link" href="{{ post.url | remove_first: '/' | absolute_url }}">
+                <a class="post-card-content-link" href="{{ post.url | remove_first: '/' | relative_url }}">
                     <header class="post-card-header">
                         {% if post.tags.size > 0 %}
                             {% for tag in post.tags %}
@@ -37,10 +37,10 @@
                     {% for author in site.data.authors %}
                         {% if author[1].username == post.author %}
                             {% if author[1].picture %}
-                            <img class="author-profile-image" src="{{ author[1].picture | absolute_url }}" alt="{{ author[1].name }}" />
+                            <img class="author-profile-image" src="{{ author[1].picture | relative_url }}" alt="{{ author[1].name }}" />
                             {% endif %}
                             <span class="post-card-author">
-                                <a href="{{ "author" | absolute_url }}/{{ post.author }}/">{{ author[1].name }}</a>
+                                <a href="{{ "author" | relative_url }}/{{ post.author }}/">{{ author[1].name }}</a>
                             </span>
                         {% endif %}
                     {% endfor %}

--- a/_includes/post-card-next.html
+++ b/_includes/post-card-next.html
@@ -2,12 +2,12 @@
 
     <article class="post-card {{ page.next.class }}{% unless page.next.cover %} no-image{% endunless %}">
         {% if page.next.cover %}
-            <a class="post-card-image-link" href="{{ page.next.url | remove_first: '/' | absolute_url }}">
-                <div class="post-card-image" style="background-image: url({{ page.next.cover | absolute_url }})"></div>
+            <a class="post-card-image-link" href="{{ page.next.url | remove_first: '/' | relative_url }}">
+                <div class="post-card-image" style="background-image: url({{ page.next.cover | relative_url }})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">
-            <a class="post-card-content-link" href="{{ page.next.url | remove_first: '/' | absolute_url }}">
+            <a class="post-card-content-link" href="{{ page.next.url | remove_first: '/' | relative_url }}">
                 <header class="post-card-header">
                     {% if page.next.tags.size > 0 %}
                         {% for tag in page.next.tags %}
@@ -33,10 +33,10 @@
                 {% for author in site.data.authors %}
                     {% if author[1].username == page.next.author %}
                         {% if author[1].picture %}
-                        <img class="author-profile-image" src="{{ author[1].picture | absolute_url }}" alt="{{ author[1].name }}" />
+                        <img class="author-profile-image" src="{{ author[1].picture | relative_url }}" alt="{{ author[1].name }}" />
                         {% endif %}
                         <span class="post-card-author">
-                            <a href="{{ "author" | absolute_url }}/{{ page.next.author }}/">{{ author[1].name }}</a>
+                            <a href="{{ "author" | relative_url }}/{{ page.next.author }}/">{{ author[1].name }}</a>
                         </span>
                     {% endif %}
                 {% endfor %}

--- a/_includes/post-card-previous.html
+++ b/_includes/post-card-previous.html
@@ -2,12 +2,12 @@
 
     <article class="post-card {{ page.previous.class }}{% unless page.previous.cover %} no-image{% endunless %}">
         {% if page.previous.cover %}
-            <a class="post-card-image-link" href="{{ page.previous.url | remove_first: '/' | absolute_url }}">
-                <div class="post-card-image" style="background-image: url({{ page.previous.cover | absolute_url }})"></div>
+            <a class="post-card-image-link" href="{{ page.previous.url | remove_first: '/' | relative_url }}">
+                <div class="post-card-image" style="background-image: url({{ page.previous.cover | relative_url }})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">
-            <a class="post-card-content-link" href="{{ page.previous.url | remove_first: '/' | absolute_url }}">
+            <a class="post-card-content-link" href="{{ page.previous.url | remove_first: '/' | relative_url }}">
                 <header class="post-card-header">
                     {% if page.previous.tags.size > 0 %}
                         {% for tag in page.previous.tags %}
@@ -33,10 +33,10 @@
                 {% for author in site.data.authors %}
                     {% if author[1].username == page.previous.author %}
                         {% if author[1].picture %}
-                        <img class="author-profile-image" src="{{ author[1].picture | absolute_url }}" alt="{{ author[1].name }}" />
+                        <img class="author-profile-image" src="{{ author[1].picture | relative_url }}" alt="{{ author[1].name }}" />
                         {% endif %}
                         <span class="post-card-author">
-                            <a href="{{ "author" | absolute_url }}/{{ page.previous.author }}/">{{ author[1].name }}</a>
+                            <a href="{{ "author" | relative_url }}/{{ page.previous.author }}/">{{ author[1].name }}</a>
                         </span>
                     {% endif %}
                 {% endfor %}

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -3,12 +3,12 @@
 {% for post in paginator.posts %}
     <article class="post-card {{ page.class }}{% unless post.cover %} no-image{% endunless %}">
         {% if post.cover %}
-            <a class="post-card-image-link" href="{{ post.url | remove_first: '/' | absolute_url }}">
-                <div class="post-card-image" style="background-image: url({{ post.cover | absolute_url }})"></div>
+            <a class="post-card-image-link" href="{{ post.url | remove_first: '/' | relative_url }}">
+                <div class="post-card-image" style="background-image: url({{ post.cover | relative_url }})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">
-            <a class="post-card-content-link" href="{{ post.url | remove_first: '/' | absolute_url }}">
+            <a class="post-card-content-link" href="{{ post.url | remove_first: '/' | relative_url }}">
                 <header class="post-card-header">
                     {% if post.tags.size > 0 %}
                         {% for tag in post.tags %}
@@ -34,10 +34,10 @@
                 {% for author in site.data.authors %}
                     {% if author[1].username == post.author %}
                         {% if author[1].picture %}
-                        <img class="author-profile-image" src="{{ author[1].picture | absolute_url }}" alt="{{ author[1].name }}" />
+                        <img class="author-profile-image" src="{{ author[1].picture | relative_url }}" alt="{{ author[1].name }}" />
                         {% endif %}
                         <span class="post-card-author">
-                            <a href="{{ "author" | absolute_url }}/{{ post.author }}/">{{ author[1].name }}</a>
+                            <a href="{{ "author" | relative_url }}/{{ post.author }}/">{{ author[1].name }}</a>
                         </span>
                     {% endif %}
                 {% endfor %}

--- a/_includes/post_pagination.html
+++ b/_includes/post_pagination.html
@@ -1,13 +1,13 @@
 <nav class="pagination" role="pagination">
     {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-            <a class="newer-posts" href="{{ "" | absolute_url }}" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "" | relative_url }}" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{ "page" | absolute_url }}{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "page" | relative_url }}{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{ paginator.page }} of {{ paginator.total_pages }} </span>
     {% if paginator.next_page %}
-        <a class="older-posts" href="{{ "page" | absolute_url }}{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
+        <a class="older-posts" href="{{ "page" | relative_url }}{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
     {% endif %}
 </nav>

--- a/_includes/site-nav.html
+++ b/_includes/site-nav.html
@@ -2,9 +2,9 @@
     <div class="site-nav-left">
         {% if page.current != 'home' %}
             {% if site.logo %}
-                <a class="site-nav-logo" href="{{ "" | absolute_url }}"><img src="{{ site.logo | absolute_url }}" alt="{{ site.title }}" /></a>
+                <a class="site-nav-logo" href="{{ "" | relative_url }}"><img src="{{ site.logo | relative_url }}" alt="{{ site.title }}" /></a>
             {% else %}
-                <a class="site-nav-logo" href="{{ "" | absolute_url }}">{{ site.title }}</a>
+                <a class="site-nav-logo" href="{{ "" | relative_url }}">{{ site.title }}</a>
             {% endif %}
         {% endif %}
         {% if page.navigation %}

--- a/_includes/tag_pagination.html
+++ b/_includes/tag_pagination.html
@@ -1,13 +1,13 @@
 <nav class="pagination" role="pagination">
     {% if paginator.previous_page %}
         {% if paginator.previous_page == 1 %}
-            <a class="newer-posts" href="{{ "tag" | absolute_url }}/{{ page.tag | slugify: "latin" }}" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "tag" | relative_url }}/{{ page.tag | slugify: "latin" }}" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{ "tag" | absolute_url }}/{{ page.tag | slugify: "latin" }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="{{ "tag" | relative_url }}/{{ page.tag | slugify: "latin" }}/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{ paginator.page }} of {{ paginator.total_pages }} </span>
     {% if paginator.next_page %}
-        <a class="older-posts" href="{{ "tag" | absolute_url }}/{{ page.tag | slugify: "latin" }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
+        <a class="older-posts" href="{{ "tag" | relative_url }}/{{ page.tag | slugify: "latin" }}/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
     {% endif %}
 </nav>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -15,12 +15,12 @@ logo: 'assets/images/ghost.png'
 <!-- Everything inside the #author tags pulls data from the author -->
 {% for author in site.data.authors %}
     {% if author[1].username == page.author %}
-    <header class="site-header outer {% if author[1].cover or page.cover %}" style="background-image: url({% if author[1].cover | absolute_url %}{{ author[1].cover }}{% elsif page.cover %}{{ page.cover }}{% endif %}) {% else %}no-cover{% endif %}">
+    <header class="site-header outer {% if author[1].cover or page.cover %}" style="background-image: url({% if author[1].cover | relative_url %}{{ author[1].cover }}{% elsif page.cover %}{{ page.cover }}{% endif %}) {% else %}no-cover{% endif %}">
         <div class="inner">
             {% include site-nav.html %}
             <div class="site-header-content">
                 {% if author[1].picture %}
-                    <img class="author-profile-image" src="{{ author[1].picture | absolute_url }}" alt="{{ page.author }}" />
+                    <img class="author-profile-image" src="{{ author[1].picture | relative_url }}" alt="{{ page.author }}" />
                 {% endif %}
                 <h1 class="site-title">{{ author[1].name }}</h1>
                 {% if author[1].bio %}
@@ -42,7 +42,7 @@ logo: 'assets/images/ghost.png'
                     {% if author[1].facebook %}
                         <a class="social-link social-link-fb" href="https://facebook.com/{{ author[1].facebook }}" target="_blank" rel="noopener">{% include facebook.html %}</a>
                     {% endif %}
-                    <a class="social-link social-link-rss" href="https://feedly.com/i/subscription/feed/{{ site.url }}{{ "author" | absolute_url }}/{{ page.author }}/feed.xml" target="_blank" rel="noopener">{% include rss.html %}</a>
+                    <a class="social-link social-link-rss" href="https://feedly.com/i/subscription/feed/{{ site.url }}{{ "author" | relative_url }}/{{ page.author }}/feed.xml" target="_blank" rel="noopener">{% include rss.html %}</a>
                 </div>
             </div>
         </div>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -15,7 +15,7 @@ logo: 'assets/images/ghost.png'
 <!-- Everything inside the #author tags pulls data from the author -->
 {% for author in site.data.authors %}
     {% if author[1].username == page.author %}
-    <header class="site-header outer {% if author[1].cover or page.cover %}" style="background-image: url({% if author[1].cover | relative_url %}{{ author[1].cover }}{% elsif page.cover %}{{ page.cover }}{% endif %}) {% else %}no-cover{% endif %}">
+    <header class="site-header outer {% if author[1].cover or page.cover %}" style="background-image: url({% if author[1].cover %}{{ author[1].cover | relative_url }}{% elsif page.cover %}{{ page.cover | relative_url }}{% endif %})">
         <div class="inner">
             {% include site-nav.html %}
             <div class="site-header-content">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,9 +12,9 @@
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Styles'n'Scripts -->
-    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.css" | absolute_url }}" />
-    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.edited.css" | absolute_url }}" />
-    <link rel="stylesheet" type="text/css" href="{{ "assets/built/syntax.css" | absolute_url }}" />
+    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.css" | relative_url }}" />
+    <link rel="stylesheet" type="text/css" href="{{ "assets/built/screen.edited.css" | relative_url }}" />
+    <link rel="stylesheet" type="text/css" href="{{ "assets/built/syntax.css" | relative_url }}" />
     <!-- highlight.js -->
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
     <style>.hljs { background: none; }</style>
@@ -58,12 +58,12 @@
         <!-- The footer at the very bottom of the screen -->
         <footer class="site-footer outer">
             <div class="site-footer-content inner">
-                <section class="copyright"><a href="{{ "" | absolute_url }}">{{ site.title }}</a> &copy; {{  site.time | date: '%Y' }}</section>
+                <section class="copyright"><a href="{{ "" | relative_url }}">{{ site.title }}</a> &copy; {{  site.time | date: '%Y' }}</section>
                 <section class="poweredby">Proudly published with <a href="https://jekyllrb.com/">Jekyll</a> &
                     <a href="https://pages.github.com/" target="_blank" rel="noopener">GitHub Pages</a> using
                     <a href="https://github.com/jekyllt/jasper2" target="_blank" rel="noopener">Jasper2</a></section>
                 <nav class="site-footer-nav">
-                    <a href="{{ "" | absolute_url }}">Latest Posts</a>
+                    <a href="{{ "" | relative_url }}">Latest Posts</a>
                     {% if site.facebook %}<a href="https://facebook.com/{{ site.facebook }}" target="_blank" rel="noopener">Facebook</a>{% endif %}
                     {% if site.twitter %}<a href="https://twitter.com/{{ site.twitter }}" target="_blank" rel="noopener">Twitter</a>{% endif %}
                 </nav>
@@ -78,7 +78,7 @@
             <a class="subscribe-overlay-close" href="#"></a>
             <div class="subscribe-overlay-content">
                 {% if site.logo %}
-                    <img class="subscribe-overlay-logo" src="{{ site.logo | absolute_url }}" alt="{{ site.title }}" />
+                    <img class="subscribe-overlay-logo" src="{{ site.logo | relative_url }}" alt="{{ site.title }}" />
                 {% endif %}
                 <h1 class="subscribe-overlay-title">Subscribe to {{ site.title }}</h1>
                 <p class="subscribe-overlay-description">Stay up to date! Get all the latest &amp; greatest posts delivered straight to your inbox</p>
@@ -101,7 +101,7 @@
         integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
         crossorigin="anonymous">
     </script>
-    <script type="text/javascript" src="{{ "assets/js/jquery.fitvids.js" | absolute_url }}"></script>
+    <script type="text/javascript" src="{{ "assets/js/jquery.fitvids.js" | relative_url }}"></script>
     <!-- <script type="text/javascript" src="https://demo.ghost.io/assets/js/jquery.fitvids.js?v=724281a32e"></script> -->
 
 
@@ -110,14 +110,14 @@
     <!-- <script>
         var maxPages = parseInt('{{ paginator.total_pages }}');
     </script>
-    <script src="{{ "assets/js/infinitescroll.js" | absolute_url }}"></script> -->
+    <script src="{{ "assets/js/infinitescroll.js" | relative_url }}"></script> -->
     <!-- /endif -->
 
     {% if paginator.total_pages > site.paginate %}
     <script>
         var maxPages = parseInt('{{ paginator.total_pages }}');
     </script>
-    <script src="{{ "assets/js/infinitescroll.js" | absolute_url }}"></script>
+    <script src="{{ "assets/js/infinitescroll.js" | relative_url }}"></script>
     {% endif %}
 
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -29,7 +29,7 @@ into the {body} of the default.hbs template -->
             </header>
 
             {% if page.cover %}
-            <figure class="post-full-image" style="background-image: url({{ page.cover | absolute_url }})">
+            <figure class="post-full-image" style="background-image: url({{ page.cover | relative_url }})">
             </figure>
             {% endif %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -31,9 +31,9 @@ into the {body} of the default.hbs template -->
                         <span class="date-divider">/</span>
                         {% for tag in page.tags %}
                             {% if forloop.index == page.tags.size %}
-                               <a href='{{ "tag" | absolute_url }}/{{ tag | slugify: "latin" }}/'>{{ tag | upcase }}</a>
+                               <a href='{{ "tag" | relative_url }}/{{ tag | slugify: "latin" }}/'>{{ tag | upcase }}</a>
                             {% else %}
-                               <a href='{{ "tag" | absolute_url }}/{{ tag | slugify: "latin" }}/'>{{ tag | upcase }}</a>,
+                               <a href='{{ "tag" | relative_url }}/{{ tag | slugify: "latin" }}/'>{{ tag | upcase }}</a>,
                             {% endif %}
                         {% endfor %}
                     {% endif %}
@@ -42,7 +42,7 @@ into the {body} of the default.hbs template -->
             </header>
 
             {% if page.cover %}
-            <figure class="post-full-image" style="background-image: url({{ page.cover | absolute_url }})">
+            <figure class="post-full-image" style="background-image: url({{ page.cover | relative_url }})">
             </figure>
             {% endif %}
 
@@ -68,19 +68,19 @@ into the {body} of the default.hbs template -->
                     {% if author[1].username == page.author %}
                         <section class="author-card">
                             {% if author[1].picture %}
-                                <img class="author-profile-image" src="{{ author[1].picture | absolute_url }}" alt="{{ page.author }}" />
+                                <img class="author-profile-image" src="{{ author[1].picture | relative_url }}" alt="{{ page.author }}" />
                             {% endif %}
                             <section class="author-card-content">
-                                <h4 class="author-card-name"><a href="{{ "author" | absolute_url }}/{{ page.author }}">{{ author[1].name }}</a></h4>
+                                <h4 class="author-card-name"><a href="{{ "author" | relative_url }}/{{ page.author }}">{{ author[1].name }}</a></h4>
                                 {% if author[1].bio %}
                                     <p>{{ author[1].bio }}</p>
                                 {% else %}
-                                    <p>Read <a href="{{ "author" | absolute_url }}/{{ page.author }}">more posts</a> by this author.</p>
+                                    <p>Read <a href="{{ "author" | relative_url }}/{{ page.author }}">more posts</a> by this author.</p>
                                 {% endif %}
                             </section>
                         </section>
                         <div class="post-full-footer-right">
-                            <a class="author-card-button" href="{{ "author" | absolute_url }}/{{ page.author }}">Read More</a>
+                            <a class="author-card-button" href="{{ "author" | relative_url }}/{{ page.author }}">Read More</a>
                         </div>
                     {% endif %}
                 {% endfor %}
@@ -131,16 +131,16 @@ into the {body} of the default.hbs template -->
                 {% if related_posts > 1 %}
                     <article class="read-next-card"
                         {% if site.cover %}
-                            style="background-image: url({{ site.cover | absolute_url }})"
+                            style="background-image: url({{ site.cover | relative_url }})"
                         {% else %}
                             {% if page.cover %}
-                                style="background-image: url(url({{ page.cover | absolute_url }})"{% endif %}
+                                style="background-image: url(url({{ page.cover | relative_url }})"{% endif %}
                         {% endif %}
                     >
                         <header class="read-next-card-header">
                             <small class="read-next-card-header-sitetitle">&mdash; {{ site.title }} &mdash;</small>
                             {% if primary %}
-                                <h3 class="read-next-card-header-title"><a href="{{ "tag" | absolute_url }}/{{ primary | slugify: "latin" }}/">{{ primary | capitalize }}</a></h3>
+                                <h3 class="read-next-card-header-title"><a href="{{ "tag" | relative_url }}/{{ primary | slugify: "latin" }}/">{{ primary | capitalize }}</a></h3>
                             {% endif %}
                         </header>
                         <div class="read-next-divider">{% include infinity.html %}</div>
@@ -152,7 +152,7 @@ into the {body} of the default.hbs template -->
                                     {% if post.title != page.title %}
                                         {% assign count = count | plus: 1 %}
                                         {% if count <= 3 %}
-                                            <li><a href="{{ post.url | remove_first: '/' | absolute_url }}">{{ post.title }}</a></li>
+                                            <li><a href="{{ post.url | remove_first: '/' | relative_url }}">{{ post.title }}</a></li>
                                         {% endif %}
                                     {% endif %}
                                   {% endif %}
@@ -160,7 +160,7 @@ into the {body} of the default.hbs template -->
                             </ul>
                         </div>
                         <footer class="read-next-card-footer">
-                            <a href="{{ "tag" | absolute_url }}/{{ primary | slugify: "latin" }}/">
+                            <a href="{{ "tag" | relative_url }}/{{ primary | slugify: "latin" }}/">
                                 {% if related_posts > 1 %}
                                     See all {{ related_posts | minus: 1 }} posts  →
                                 {% elsif related_posts == 1 %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -134,7 +134,7 @@ into the {body} of the default.hbs template -->
                             style="background-image: url({{ site.cover | relative_url }})"
                         {% else %}
                             {% if page.cover %}
-                                style="background-image: url(url({{ page.cover | relative_url }})"{% endif %}
+                                style="background-image: url({{ page.cover | relative_url }})"{% endif %}
                         {% endif %}
                     >
                         <header class="read-next-card-header">

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -14,7 +14,7 @@ logo: 'assets/images/ghost.png'
 <!-- The big featured header, it uses blog cover image as a BG if available -->
 <!-- #tag -->
 {% include dynamic_tag_info.html %}
-<header class="site-header outer {% if cover or page.cover %}" style="background-image: url({% if cover %}{{ cover }}{% else %}{{ page.cover | absolute_url }}{% endif%}) {% else %}no-cover{% endif %}">
+<header class="site-header outer {% if cover or page.cover %}" style="background-image: url({% if cover %}{{ cover }}{% else %}{{ page.cover | relative_url }}{% endif%}) {% else %}no-cover{% endif %}">
     <div class="inner">
         {% include site-nav.html %}
         <div class="site-header-content">

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ navigation: True
 
 <header
   class="site-header outer {% if page.cover or site.cover %}"
-  style="background-image:  url({% if page.cover %}{{ page.cover | absolute_url }}{% elsif site.cover %}{{ site.cover | absolute_url }}{% endif %}) {% else %}no-cover{% endif %}"
+  style="background-image:  url({% if page.cover %}{{ page.cover | relative_url }}{% elsif site.cover %}{{ site.cover | relative_url }}{% endif %}) {% else %}no-cover{% endif %}"
 >
   <div class="inner">
     <div class="site-header-content">
@@ -24,7 +24,7 @@ navigation: True
         {% if site.logo %}
         <img
           class="site-logo"
-          src="{{ site.logo | absolute_url }}"
+          src="{{ site.logo | relative_url }}"
           alt="{{ site.title }}"
         />
         {% else %} {{ site.title }} {% endif %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated all site links and asset references to use relative URLs instead of absolute URLs. This change affects navigation menus, pagination, post cards, author and tag pages, images, stylesheets, and scripts throughout the site. All links and resources will now be referenced as paths relative to the current page. No visual changes or functional logic were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->